### PR TITLE
Version 3.0.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,16 @@
 # AntelopeQL changelog
 
+## 3.0.1
+
+### Patch
+
+- Removed usage of `import("node:crypto")` which caused `UnhandledSchemeError` in Next.js / Webpack.
+- Replaced Node-only SHA256 implementation with **universal WebCrypto-based version** compatible with:
+  - Browser
+  - Edge Runtime
+  - Node 18+ (`globalThis.crypto.subtle`)
+- Fully resolved TypeScript type errors related to:
+
 ## 3.0.0
 
 ### Major

--- a/src/utils/sha256.ts
+++ b/src/utils/sha256.ts
@@ -1,18 +1,13 @@
 export async function sha256(data: Uint8Array): Promise<Uint8Array> {
-  // Browser or Edge Runtime
-  if (typeof crypto !== "undefined" && crypto.subtle) {
-    // @ts-ignore - WebCrypto subtle.digest accepts Uint8Array at runtime; TS incorrectly rejects ArrayBufferLike
-    const digest = await crypto.subtle.digest("SHA-256", data);
+  const cryptoObj = globalThis.crypto;
 
-    return new Uint8Array(digest);
-  }
+  if (!cryptoObj?.subtle)
+    throw new Error("WebCrypto SHA-256 is not available in this environment.");
 
-  // Node.js (uses built-in `crypto`)
-  if (typeof process !== "undefined" && process.versions?.node) {
-    const { createHash } = await import("node:crypto");
-    const hash = createHash("sha256").update(data).digest();
-    return new Uint8Array(hash);
-  }
+  const digest = await cryptoObj.subtle.digest(
+    "SHA-256",
+    data as unknown as BufferSource
+  );
 
-  throw new Error("SHA-256 is not supported in this environment.");
+  return new Uint8Array(digest);
 }


### PR DESCRIPTION
## 3.0.1

### Patch

- Removed usage of `import("node:crypto")` which caused `UnhandledSchemeError` in Next.js / Webpack.
- Replaced Node-only SHA256 implementation with **universal WebCrypto-based version** compatible with:
  - Browser
  - Edge Runtime
  - Node 18+ (`globalThis.crypto.subtle`)
- Fully resolved TypeScript type errors related to: